### PR TITLE
Fixes exception when build configuration has no VCS root

### DIFF
--- a/Sources/Beacon.Core/Models/Build.cs
+++ b/Sources/Beacon.Core/Models/Build.cs
@@ -10,7 +10,7 @@ namespace Beacon.Core.Models
             return new Build
             {
                 Id = long.Parse(element.Attribute("id").Value),
-                BranchName = element.Attribute("branchName").Value,
+                BranchName = element.Attribute("branchName")?.Value ?? "<no branch; build has no VCS root>",
                 IsRunning = !element.Attribute("state").Value.Equals("finished", StringComparison.InvariantCultureIgnoreCase),
                 IsSuccessful = element.Attribute("status").Value.Equals("success", StringComparison.CurrentCultureIgnoreCase)
             };

--- a/Sources/Beacon.Core/TeamCityMonitor.cs
+++ b/Sources/Beacon.Core/TeamCityMonitor.cs
@@ -179,7 +179,7 @@ namespace Beacon.Core
                 return BuildStatus.Passed;
             }
 
-            Logger.Verbose($"Build from branch {firstUnsuccesful.BranchName}(id: {firstUnsuccesful.Id}) failed");
+            Logger.Verbose($"Build from branch {firstUnsuccesful.BranchName} (id: {firstUnsuccesful.Id}) failed");
 
             if (buildType.IsUnstable)
             {


### PR DESCRIPTION
When monitoring a build configuration without an attached VCS root Beacon throws an exception because the build information does not contain `branchName` information. See issue #17.

This PR fixes the exception by showing a default text when no VCS root is attached to the build configuration.

Fixes #17.