### PR TITLE
Remove XML documentation files from package

### DIFF
--- a/Sources/Beacon/Beacon.csproj
+++ b/Sources/Beacon/Beacon.csproj
@@ -52,6 +52,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
     <LangVersion>7</LangVersion>
+    <AllowedReferenceRelatedFileExtensions>.pdb;</AllowedReferenceRelatedFileExtensions>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine">


### PR DESCRIPTION
Removes the XML documentation files (for referenced packages) from the package as requested by Chocolatey.org Moderation.