### PR TITLE
Upgrade CommandLineParser

### DIFF
--- a/Sources/Beacon.Core/Logger.cs
+++ b/Sources/Beacon.Core/Logger.cs
@@ -6,7 +6,7 @@ namespace Beacon.Core
     {
         public static void WriteLine(string message, params object[] parameters)
         {
-            var messageToLog = String.Format(message, parameters);
+            var messageToLog = string.Format(message, parameters);
             Console.WriteLine("{0} {1}", DateTime.Now.ToShortTimeString(), messageToLog);
         }
 
@@ -14,8 +14,8 @@ namespace Beacon.Core
         {
             if (VerboseEnabled)
             {
-                Console.WriteLine("VERBOSE: {0} {1}", DateTime.Now.ToShortTimeString(),
-                    String.Format(message, parameters));
+                var messageToLog = string.Format(message, parameters);
+                Console.WriteLine("VERBOSE: {0} {1}", DateTime.Now.ToShortTimeString(), messageToLog);
             }
         }
 

--- a/Sources/Beacon/Beacon.csproj
+++ b/Sources/Beacon/Beacon.csproj
@@ -54,8 +54,8 @@
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine">
-      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.2.1.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.2.1\lib\net45\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Sources/Beacon/packages.config
+++ b/Sources/Beacon/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
+  <package id="CommandLineParser" version="2.2.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Upgrades CommandLineParser package to version 2.2.1 (from 1.9.71). Allows for better checking of the command-line arguments passed to Beacon.

```
PS E:\Tools\Beacon> .\Beacon.exe
Beacon: TeamCity Monitor 1.2.1.4
Copyright (C) 2015 - 2018 Dennis Doomen
ERROR(S):
Required option 'username' is missing.
Required option 'password' is missing.
Required option 'g, guestaccess' is missing.
Required option 'url' is missing.
Required option 'builds' is missing.
USAGE:
Using TeamCity credentials:
Beacon.exe --builds SomeBuildId SomeOtherBuildId --password pass --url http://teamcity.local --username user
Using TeamCity guest access and running only once before exiting:
Beacon.exe -gr --builds SomeBuildId SomeOtherBuildId --url http://teamcity.local
Using TeamCity guest access, running only once before exiting and verbose logging:
Beacon.exe -grv --builds SomeBuildId SomeOtherBuildId --url http://teamcity.local

  --url                Required. The root URL of the TeamCity server.

  --username           Required. The username of the account that has read access to TeamCity. Options username/password and guestaccess are mutually exclusive.

  --password           Required. The password of the account that has read access to TeamCity.

  --builds             Required. One or more builds identified by their TeamCity id (eg, bt64 bt12 or * for all).

  --device             (Default: delcom) The device to use as the build light (e.g. console, delcom).

  --interval           (Default: 10) The interval in seconds at which to check the build status.

  --timespan           (Default: 7) The timespan in days to include builds from.

  -g, --guestaccess    Required. Check the build status using the TeamCity guest account. Options guestaccess and username/password are mutually exclusive.

  -r, --runonce        (Default: false) Check the build status only once.

  -v, --verbose        Log verbose messages.

  --help               Display this help screen.

  --version            Display version information.
```