### PR TITLE
Changes log level for build status log messages

### DIFF
--- a/Sources/Beacon.Core/TeamCityMonitor.cs
+++ b/Sources/Beacon.Core/TeamCityMonitor.cs
@@ -130,7 +130,7 @@ namespace Beacon.Core
                         statusPerBuild.Add(status.Value);
                     }
 
-                    Logger.Verbose($"Status of Built Type '{buildType.Id}' is {status ?? BuildStatus.Unavailable}.");
+                    Logger.WriteLine($"Status of build type '{buildType.Id}' is {status ?? BuildStatus.Unavailable}.");
                 }
                 else
                 {


### PR DESCRIPTION
Changes the log level to informational instead of verbose for build status log messages to improve informational logging. This way Beacon provides clean informational logging like this:

```
3:37 PM Status of build type 'Compilation' is Passed.
3:37 PM Status of build type 'SmokeTests' is Failed.
3:37 PM Failed
```

With optional verbose logging like this:

```
VERBOSE: 3:40 PM Switching LED to OFF.
VERBOSE: 3:40 PM Analyzing the builds for 'Compilation' over a period of 7 days.
VERBOSE: 3:40 PM Analyzing the builds for 'SmokeTests' over a period of 7 days.
VERBOSE: 3:40 PM Build from branch develop (id: 999) failed
VERBOSE: 3:40 PM Now checking investigation status.
3:40 PM Status of build type 'SmokeTests' is Failed.
VERBOSE: 3:40 PM Switching LED to RED.
3:40 PM Failed
```
