### PR TITLE
Add color highlighting to output

### DIFF
--- a/Sources/Beacon.Core/Logger.cs
+++ b/Sources/Beacon.Core/Logger.cs
@@ -4,6 +4,22 @@ namespace Beacon.Core
 {
     public class Logger
     {
+        public static void WriteErrorLine(string message, params object[] parameters)
+        {
+            var foregroundColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Red;
+            WriteLine(message, parameters);
+            Console.ForegroundColor = foregroundColor;
+        }
+
+        public static void WriteWarningLine(string message, params object[] parameters)
+        {
+            var foregroundColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            WriteLine(message, parameters);
+            Console.ForegroundColor = foregroundColor;
+        }
+
         public static void WriteLine(string message, params object[] parameters)
         {
             var messageToLog = string.Format(message, parameters);

--- a/Sources/Beacon.Core/TeamCityMonitor.cs
+++ b/Sources/Beacon.Core/TeamCityMonitor.cs
@@ -33,7 +33,7 @@ namespace Beacon.Core
         {
             var buildTypeIds = config.BuildTypeIds == "*"
                 ? new string[0]
-                : config.BuildTypeIds.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries).ToArray();
+                : config.BuildTypeIds.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).ToArray();
 
             buildLight.NoStatus();
 
@@ -131,7 +131,19 @@ namespace Beacon.Core
                         statusPerBuild.Add(status.Value);
                     }
 
-                    Logger.WriteLine($"Status of build type '{buildType.Id}' is {status ?? BuildStatus.Unavailable}.");
+                    var statusMessage = $"Status of build type '{buildType.Id}' is {status ?? BuildStatus.Unavailable}.";
+                    switch (status)
+                    {
+                        case BuildStatus.Failed:
+                            Logger.WriteErrorLine(statusMessage);
+                            break;
+                        case BuildStatus.Investigating:
+                            Logger.WriteWarningLine(statusMessage);
+                            break;
+                        default:
+                            Logger.WriteLine(statusMessage);
+                            break;
+                    }
                 }
                 else
                 {
@@ -152,7 +164,7 @@ namespace Beacon.Core
 
             var fromDate = DateTimeOffset.Now.Subtract(config.TimeSpan);
             string fromDateInTcFormat = Uri.EscapeDataString(fromDate.ToString("yyyyMMdd'T'HHmmssK").Replace(":", ""));
-            
+
             string buildsXml = await httpClient.GetStringAsync(
                     $"{authPath}/app/rest/buildTypes/id:{buildType.Id}/builds?locator=branch:default:any,running:false,sinceDate:{fromDateInTcFormat}");
 


### PR DESCRIPTION
Adds color highlighting to the console output depending on the build status. The text of the output (line) is made red for builds with failed status and yellow for build with investigation status.