### PR TITLE
Fix assembly version used in build

### DIFF
--- a/Build/default.ps1
+++ b/Build/default.ps1
@@ -58,7 +58,7 @@ task ExtractVersionsFromGit {
           
             TeamCity-SetBuildNumber $version.FullSemVer;
             
-            $script:AssemblyVersion = $version.ClassicVersion;
+            $script:AssemblyVersion = $version.AssemblySemVer;
             $script:InformationalVersion = $version.InformationalVersion;
             $script:NuGetVersion = $version.NuGetVersionV2;
         }

--- a/Package/Beacon.nuspec
+++ b/Package/Beacon.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>beacon</id>
     <title>Beacon</title>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
     <owners>Dennis Doomen</owners>
     <authors>Dennis Doomen</authors>
     <summary>

--- a/Sources/SharedAssemblyInfo.cs
+++ b/Sources/SharedAssemblyInfo.cs
@@ -2,6 +2,6 @@ using System.Reflection;
 
 [assembly: AssemblyCopyright("Copyright © Dennis Doomen 2015-2018")]
 
-[assembly: AssemblyVersion("1.2.1.4")]
-[assembly: AssemblyFileVersion("1.2.1.4")]
-[assembly: AssemblyInformationalVersion("1.2.1+4.Branch.master.Sha.ba6198e04e7d2093848a93ecfc76f2632da62bd9")]
+[assembly: AssemblyVersion("1.2.3.0")]
+[assembly: AssemblyFileVersion("1.2.3.0")]
+[assembly: AssemblyInformationalVersion("1.2.3+1.Branch.master.Sha.cb7541cb093b89669f4188bb63a043a6a5a0b99e")]


### PR DESCRIPTION
The build script used a GitVersion attribute not (or no longer) available in the output of GitVersion. Because of this the 1.2.2 release has assembly version 1.2.1.4. The NuGet version was not affected as it depended on another GitVersion attribute.