### PR TITLE
Removes verbose logging comment to better align Beacon output

### DIFF
--- a/Sources/Beacon.Core/Logger.cs
+++ b/Sources/Beacon.Core/Logger.cs
@@ -30,8 +30,7 @@ namespace Beacon.Core
         {
             if (VerboseEnabled)
             {
-                var messageToLog = string.Format(message, parameters);
-                Console.WriteLine("VERBOSE: {0} {1}", DateTime.Now.ToShortTimeString(), messageToLog);
+                WriteLine(message, parameters);
             }
         }
 


### PR DESCRIPTION
Normal output:
```
12:53 PM Status of build type 'Compilation' is Passed.
12:53 PM Status of build type 'UnitTests' is Failed.
12:53 PM Failed
```
Verbose output before:
```
VERBOSE: 12:53 PM Switching LED to OFF.
VERBOSE: 12:53 PM Analyzing the builds for 'Compilation' over a period of 7 days.
12:53 PM Status of build type 'Compilation' is Passed.
VERBOSE: 12:53 PM Analyzing the builds for 'UnitTests' over a period of 7 days.
VERBOSE: 12:53 PM Build from branch hotfix-7.12.2 (id: 37661) failed
VERBOSE: 12:53 PM Now checking investigation status.
12:53 PM Status of build type 'UnitTests' is Failed.
VERBOSE: 12:53 PM Switching LED to RED.
12:53 PM Failed
```
Verbose output after:
```
12:53 PM Switching LED to OFF.
12:53 PM Analyzing the builds for 'Compilation' over a period of 7 days.
12:53 PM Status of build type 'Compilation' is Passed.
12:53 PM Analyzing the builds for 'UnitTests' over a period of 7 days.
12:53 PM Build from branch hotfix-7.12.2 (id: 37661) failed
12:53 PM Now checking investigation status.
12:53 PM Status of build type 'UnitTests' is Failed.
12:53 PM Switching LED to RED.
12:53 PM Failed
```