### PR TITLE
Add options to monitor all/active branches and monitor failed to start builds

### DIFF
--- a/Sources/Beacon.Core/Config.cs
+++ b/Sources/Beacon.Core/Config.cs
@@ -28,5 +28,9 @@ namespace Beacon.Core
         /// Check the build status using the TeamCity guest account.
         /// </summary>
         public bool GuestAccess { get; set; }
+
+        public bool IncludeAllBranches { get; set; }
+
+        public bool IncludeFailedToStart { get; set; }
     }
 }

--- a/Sources/Beacon/Options.cs
+++ b/Sources/Beacon/Options.cs
@@ -35,6 +35,12 @@ namespace Beacon
         [Option("timespan", Default = 7, HelpText = "The timespan in days to include builds from.")]
         public int Timespan { get; set; }
 
+        [Option('a', "all", Default = false, HelpText = "Monitor builds for all branches, not just active branches.")]
+        public bool IncludeAllBranches { get; set; }
+        
+        [Option('f', "failed", Default = false, HelpText = "Monitor builds that failed to start as well, not just finished builds.")]
+        public bool IncludeFailedToStart { get; set; }
+
         [Option('g', "guestaccess", Required = true,
             HelpText = 
                 "Check the build status using the TeamCity guest account. Options guestaccess and username/password are mutually exclusive.", 

--- a/Sources/Beacon/Program.cs
+++ b/Sources/Beacon/Program.cs
@@ -48,7 +48,9 @@ namespace Beacon
                 TimeSpan = TimeSpan.FromDays(options.Timespan),
                 BuildTypeIds = string.Join(",", options.BuildTypeIds),
                 RunOnce = options.RunOnce,
-                GuestAccess = options.GuestAccess
+                GuestAccess = options.GuestAccess,
+                IncludeAllBranches = options.IncludeAllBranches,
+                IncludeFailedToStart = options.IncludeFailedToStart
             };
 
             Logger.VerboseEnabled = options.Verbose;


### PR DESCRIPTION
Adds an option to monitor active branches only. Enabling this option shows builds for branches considered 'active' by TeamCity. It is configurable in TeamCity which branches are active. See [Working with Feature Branches](https://confluence.jetbrains.com/display/TCD10/Working+with+Feature+Branches#WorkingwithFeatureBranches-Activebranches).

Adds an option to include failed to start builds when checking for the build status. See [Build State](https://confluence.jetbrains.com/display/TCD10/Build+State#BuildState-FailedtoStartBuilds).

Solves #25 and #27.