### PR TITLE
Improves Beacon logging to console output

### DIFF
--- a/Sources/Beacon.Core/Logger.cs
+++ b/Sources/Beacon.Core/Logger.cs
@@ -6,18 +6,16 @@ namespace Beacon.Core
     {
         public static void WriteErrorLine(string message, params object[] parameters)
         {
-            var foregroundColor = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Red;
             WriteLine(message, parameters);
-            Console.ForegroundColor = foregroundColor;
+            Console.ResetColor();
         }
 
         public static void WriteWarningLine(string message, params object[] parameters)
         {
-            var foregroundColor = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Yellow;
             WriteLine(message, parameters);
-            Console.ForegroundColor = foregroundColor;
+            Console.ResetColor();
         }
 
         public static void WriteLine(string message, params object[] parameters)
@@ -36,7 +34,7 @@ namespace Beacon.Core
 
         public static void Error(Exception exception)
         {
-            WriteLine(exception.ToString());
+            WriteErrorLine(exception.ToString());
         }
 
         public static bool VerboseEnabled { get; set; }

--- a/Sources/Beacon.Core/TeamCityMonitor.cs
+++ b/Sources/Beacon.Core/TeamCityMonitor.cs
@@ -40,8 +40,6 @@ namespace Beacon.Core
                 ? new string[0]
                 : config.BuildTypeIds.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).ToArray();
 
-            buildLight.NoStatus();
-
             Console.CancelKeyPress += delegate { buildLight.NoStatus(); };
 
             do
@@ -196,13 +194,13 @@ namespace Beacon.Core
                 }
             }
 
-            Build firstUnsuccesful = dictionary.Values.FirstOrDefault(v => !v.IsSuccessful);
-            if (firstUnsuccesful == null)
+            Build firstFailingBuild = dictionary.Values.FirstOrDefault(v => !v.IsSuccessful);
+            if (firstFailingBuild == null)
             {
                 return BuildStatus.Passed;
             }
 
-            Logger.Verbose($"Build from branch {firstUnsuccesful.BranchName} (id: {firstUnsuccesful.Id}) failed");
+            Logger.Verbose($"Build from branch {firstFailingBuild.BranchName} (id: {firstFailingBuild.Id}) failed");
 
             if (buildType.IsUnstable)
             {

--- a/Sources/Beacon.Lights/Console/ConsoleBuildLight.cs
+++ b/Sources/Beacon.Lights/Console/ConsoleBuildLight.cs
@@ -6,46 +6,39 @@ namespace Beacon.Lights.Console
 {
     internal class ConsoleBuildLight : IBuildLight
     {
-        private readonly ConsoleColor defaultForegroundColor;
-
-        public ConsoleBuildLight()
-        {
-            defaultForegroundColor = System.Console.ForegroundColor;
-        }
-
         public void Success()
         {
             System.Console.ForegroundColor = ConsoleColor.Green;
             System.Console.WriteLine("Build is successful");
-            System.Console.ForegroundColor = defaultForegroundColor;
+            System.Console.ResetColor();
         }
 
         public void Investigate()
         {
             System.Console.ForegroundColor = ConsoleColor.Yellow;
             System.Console.WriteLine("Build is being investigated");
-            System.Console.ForegroundColor = defaultForegroundColor;
+            System.Console.ResetColor();
         }
 
         public void Fail()
         {
             System.Console.ForegroundColor = ConsoleColor.Red;
             System.Console.WriteLine("Build has failed");
-            System.Console.ForegroundColor = defaultForegroundColor;
+            System.Console.ResetColor();
         }
 
         public void Fixed()
         {
             System.Console.ForegroundColor = ConsoleColor.DarkGreen;
             System.Console.WriteLine("Build is successful");
-            System.Console.ForegroundColor = defaultForegroundColor;
+            System.Console.ResetColor();
         }
 
         public void NoStatus()
         {
             System.Console.ForegroundColor = ConsoleColor.DarkGray;
             System.Console.WriteLine("Build status is unknown");
-            System.Console.ForegroundColor = defaultForegroundColor;
+            System.Console.ResetColor();
         }
     }
 }

--- a/Sources/Beacon.sln.DotSettings
+++ b/Sources/Beacon.sln.DotSettings
@@ -72,4 +72,9 @@ public void When_$scenario$_it_should_$behavior$()&#xD;
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Applicability/=Live/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Scope/=C3001E7C0DA78E4487072B7E050D86C5/@KeyIndexDefined">True</s:Boolean>
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Scope/=C3001E7C0DA78E4487072B7E050D86C5/Type/@EntryValue">InCSharpFile</s:String>
-	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Scope/=C3001E7C0DA78E4487072B7E050D86C5/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Scope/=C3001E7C0DA78E4487072B7E050D86C5/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=delcom/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=delcomdll/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Doomen/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=guestaccess/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=runonce/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Improve logging by using `ResetColor` to reset console colors to the original colors when the process was started.