### PR TITLE
Add an option to only monitor the default branch

### DIFF
--- a/Sources/Beacon.Core/Config.cs
+++ b/Sources/Beacon.Core/Config.cs
@@ -32,5 +32,10 @@ namespace Beacon.Core
         public bool IncludeAllBranches { get; set; }
 
         public bool IncludeFailedToStart { get; set; }
+        
+        /// <summary>
+        /// Only check the build status on the default branch.
+        /// </summary>
+        public bool OnlyDefaultBranch { get; set; }
     }
 }

--- a/Sources/Beacon.Core/Models/Build.cs
+++ b/Sources/Beacon.Core/Models/Build.cs
@@ -12,7 +12,8 @@ namespace Beacon.Core.Models
                 Id = long.Parse(element.Attribute("id").Value),
                 BranchName = element.Attribute("branchName")?.Value ?? "<no branch; build has no VCS root>",
                 IsRunning = !element.Attribute("state").Value.Equals("finished", StringComparison.InvariantCultureIgnoreCase),
-                IsSuccessful = element.Attribute("status").Value.Equals("success", StringComparison.CurrentCultureIgnoreCase)
+                IsSuccessful = element.Attribute("status").Value.Equals("success", StringComparison.CurrentCultureIgnoreCase),
+                DefaultBranch = element.Attribute("defaultBranch")?.Value.Equals("true", StringComparison.CurrentCultureIgnoreCase) ?? false
             };
         }
 
@@ -23,5 +24,7 @@ namespace Beacon.Core.Models
         public long Id { get; set; }
 
         public string BranchName { get; set; }
+        
+        public bool DefaultBranch { get; set; }
     }
 }

--- a/Sources/Beacon.Core/TeamCityMonitor.cs
+++ b/Sources/Beacon.Core/TeamCityMonitor.cs
@@ -188,6 +188,9 @@ namespace Beacon.Core
             {
                 string branch = build.BranchName;
 
+                if (config.OnlyDefaultBranch && !build.DefaultBranch)
+                    continue;
+                
                 if (!dictionary.ContainsKey(branch) || dictionary[branch].Id < build.Id)
                 {
                     dictionary[branch] = build;

--- a/Sources/Beacon/Options.cs
+++ b/Sources/Beacon/Options.cs
@@ -52,6 +52,9 @@ namespace Beacon
 
         [Option('v', "verbose", HelpText = "Log verbose messages.")]
         public bool Verbose { get; set; }
+        
+        [Option('d', "defaultbranch", Default = false, HelpText = "Only monitor the status of the default branch")]
+        public bool OnlyDefaultBranch { get; set; }
 
         [Usage(ApplicationAlias = "Beacon.exe")]
         public static IEnumerable<Example> Examples

--- a/Sources/Beacon/Program.cs
+++ b/Sources/Beacon/Program.cs
@@ -50,7 +50,8 @@ namespace Beacon
                 RunOnce = options.RunOnce,
                 GuestAccess = options.GuestAccess,
                 IncludeAllBranches = options.IncludeAllBranches,
-                IncludeFailedToStart = options.IncludeFailedToStart
+                IncludeFailedToStart = options.IncludeFailedToStart,
+                OnlyDefaultBranch = options.OnlyDefaultBranch,
             };
 
             Logger.VerboseEnabled = options.Verbose;


### PR DESCRIPTION
For our integration test use-case, we are only interested in showing the status of the default branch.

This adds an additional option to only check the status of the default branch