### PR TITLE
Add Shelly bulb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Beacon
 
-A monitoring tool for Azure DevOps and Teamcity that uses a Delcom USB LED light to notify your teams.
+A monitoring tool for Azure DevOps and Teamcity that uses a Delcom USB LED or Shelly Bulb light to notify your teams.
 
 ![Chocolate](./Images/Screenshot.png)
 
@@ -33,6 +33,14 @@ Using a named TeamCity account and running continuously:
 Or, alternatively using TeamCity guest access, running only once and with verbose logging:
 
     beacon teamcity --url=http://yourteamcity.com --guestaccess --runonce --verbose --builds=build_id_1 build_id_2 etc
+
+## Using a Shelly Bulb
+First install your Shelly Bulb following the installation [instructions](https://shelly.cloud/documents/user_guide/shelly_bulb.pdf).
+After your bulb is installed, look up the device IP address of it under "Settings > Device Information", e.g. 10.25.31.27.
+
+Now use the obtained IP to connect Shelly:
+
+    beacon azuredevops --url https://dev.azure.com/avivasolutions-public --project Nyxie --builds 10 --device shelly --shellyurl http://10.25.31.27
 
 ## Backlog
 

--- a/Sources/Beacon.Lights/Beacon.Lights.csproj
+++ b/Sources/Beacon.Lights/Beacon.Lights.csproj
@@ -50,6 +50,10 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="RestSharp, Version=104.5.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\RestSharp.104.5.0\lib\net4\RestSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -68,12 +72,17 @@
     <Compile Include="Delcom\DelcomLight.cs" />
     <Compile Include="LightFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Shelly\ShellyBulb.cs" />
+    <Compile Include="Shelly\ShellyLight.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Beacon.Core\Beacon.Core.csproj">
       <Project>{E76813EF-60AD-4955-A273-C2A235DFE9FC}</Project>
       <Name>Beacon.Core</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Sources/Beacon.Lights/LightFactory.cs
+++ b/Sources/Beacon.Lights/LightFactory.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Beacon.Core;
 using Beacon.Lights.Console;
 using Beacon.Lights.Delcom;
+using Beacon.Lights.Shelly;
 
 namespace Beacon.Lights
 {
@@ -16,6 +17,7 @@ namespace Beacon.Lights
         {
             devices.Add("console", new ConsoleBuildLight());
             devices.Add("delcom", new DelcomLight());
+            devices.Add("shelly", new ShellyLight());
         }
 
         public string[] SupportedDevices

--- a/Sources/Beacon.Lights/Shelly/ShellyBulb.cs
+++ b/Sources/Beacon.Lights/Shelly/ShellyBulb.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+
+using Beacon.Core;
+
+using RestSharp;
+
+namespace Beacon.Lights.Shelly
+{
+    public class ShellyBulb
+    {
+        private string url { get; set; }
+
+        public void Configure(string url)
+        {
+            this.url = url;
+        }
+        
+        public void Set(byte red, byte green, byte blue)
+        {
+            var request = new RestRequest("light/0", Method.POST);
+
+            request.AddParameter("mode", "color", ParameterType.GetOrPost);
+            request.AddParameter("gain", 100, ParameterType.GetOrPost);
+            request.AddParameter("turn", "on", ParameterType.GetOrPost);
+            
+            request.AddParameter("red", red, ParameterType.GetOrPost);
+            request.AddParameter("green", green, ParameterType.GetOrPost);
+            request.AddParameter("blue", blue, ParameterType.GetOrPost);
+            
+            Send(request);
+        }
+
+        public void Off()
+        {
+            var request = new RestRequest("settings", Method.POST);
+            request.AddParameter("turn", "off", ParameterType.GetOrPost);
+            
+            Send(request);
+        }
+
+        private void Send(RestRequest request)
+        {
+            try
+            {
+                var client = new RestClient(url);
+                var response = client.Execute(request);
+                
+                if (response.ErrorException != null)
+                {
+                    throw response.ErrorException;
+                }
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    Logger.WriteErrorLine($"Failed to send command to Shelly bulb (@ {url}): {response.StatusDescription}");
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e);
+            }
+        }
+    }
+}

--- a/Sources/Beacon.Lights/Shelly/ShellyLight.cs
+++ b/Sources/Beacon.Lights/Shelly/ShellyLight.cs
@@ -1,0 +1,54 @@
+﻿using Beacon.Core;
+
+namespace Beacon.Lights.Shelly
+{
+    public class ShellyLight : IBuildLight
+    {
+        private readonly ShellyBulb bulb;
+
+        public ShellyLight()
+        {
+            bulb = new ShellyBulb();
+        }
+
+        public void Configure(string url)
+        {
+            bulb.Configure(url);
+        }
+
+        public void Success()
+        {
+            VerboseThemeChange("GREEN");
+            bulb.Set(0, 255, 0);
+        }
+
+        public void Fixed()
+        {
+            VerboseThemeChange("GREEN");
+            bulb.Set(0, 255, 0);
+        }
+
+        public void Investigate()
+        {
+            VerboseThemeChange("ORANGE");
+            bulb.Set(255, 215, 0);
+        }
+
+        public void Fail()
+        {
+            VerboseThemeChange("RED");
+            bulb.Set(255, 0, 0);
+        }
+
+        public void NoStatus()
+        {
+            VerboseThemeChange("OFF");
+            bulb.Off();
+        }
+        
+        private static void VerboseThemeChange(string newTheme)
+        {
+            Logger.Verbose("Switching LED to {0}.", newTheme);
+        }
+    }
+}

--- a/Sources/Beacon.Lights/packages.config
+++ b/Sources/Beacon.Lights/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="RestSharp" version="104.5.0" targetFramework="net45" />
+</packages>

--- a/Sources/Beacon/Options.cs
+++ b/Sources/Beacon/Options.cs
@@ -7,8 +7,11 @@ namespace Beacon
     internal class Options
     {
         [Option("device", Default = "delcom", 
-            HelpText = "The device to use as the build light (e.g. console, delcom).")]
+            HelpText = "The device to use as the build light (e.g. console, delcom, shelly).")]
         public string Device { get; set; }
+        
+        [Option("shellyurl", HelpText = "The base URL of the Shelly Bulb")]
+        public string ShellyUrl { get; set; }
         
         [Option('r', "runonce", Default = false, HelpText = "Check the build status only once.")]
         public bool RunOnce { get; set; }

--- a/Sources/Beacon/Program.cs
+++ b/Sources/Beacon/Program.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 
 using Beacon.Core;
 using Beacon.Lights;
+using Beacon.Lights.Shelly;
+
 using CommandLine;
 using CommandLine.Text;
 
@@ -42,6 +44,10 @@ namespace Beacon
         private static void RunTeamCityMonitor(TeamcityOptions options)
         {
             var buildLight = new LightFactory().CreateLight(options.Device);
+            if (buildLight is ShellyLight)
+            {
+                (buildLight as ShellyLight).Configure(options.ShellyUrl);
+            }
             var config = new TeamcityConfig
             {
                 ServerUrl = options.Url,
@@ -64,6 +70,10 @@ namespace Beacon
         private static void RunAzureDevopsMonitor(AzureDevOpsOptions options)
         {
             var buildLight = new LightFactory().CreateLight(options.Device);
+            if (buildLight is ShellyLight)
+            {
+                (buildLight as ShellyLight).Configure(options.ShellyUrl);
+            }
             var config = new AzureDevOpsConfig()
             {
                 Url = new Uri(options.Url),


### PR DESCRIPTION
This PR adds Shelly Bulb support. 

A Shelly Bulb is a ~25 euro RGB color light bulb which can be controlled over WIFI: https://shelly.cloud/products/shelly-bulb-smart-home-automation-device/